### PR TITLE
Fixed app link

### DIFF
--- a/apps.json
+++ b/apps.json
@@ -402,7 +402,7 @@
       "@context": "http://schema.org",
       "@type": "SoftwareApplication",
       "permissions": ["/api/apps.json"],
-      "name": "applist",
+      "name": "",
       "headline": "loklak app list",
       "alternativeHeadline": "work from GCI task",
       "applicationCategory": "About Project",


### PR DESCRIPTION
Fixes #54 
Clicking on applist now redirects to home page of apps.loklak.org