### PR TITLE
Fixes #196: Added Emoji marker instead of points in emojiHeatmapper app

### DIFF
--- a/emojiHeatmapper/script.js
+++ b/emojiHeatmapper/script.js
@@ -9,22 +9,28 @@ var pointFeature = new ol.Feature(point);
 // Source and vector layer
 var vectorSource = new ol.source.Vector();
 
-var style = new ol.style.Style({
-    image: new ol.style.Circle({
-        fill: new ol.style.Fill({
-            color: 'rgba(255, 100, 50, 0.3)'
-        }),
-        stroke: new ol.style.Stroke({
-            width: 1,
-            color: 'rgba(255, 100, 50, 0.8)'
-        }),
-        radius: 7
+var style = new ol.style,Style({
+    stroke: new ol.style.Stroke({
+        color: [64, 200, 200, 0.5],
+        width: 5
     }),
+    text: new ol.style.Text({
+        font: '30px sans-serif',
+        text: document.getElementById('searchField').value !== '' ? document.getElementById('searchField').value : '',
+        fill: new ol.style.Fill({
+            color: [64, 64, 64, 0.75]
+        })
+    })
 });
+
+var styles = [style];
 
 var vectorLayer = new ol.layer.Vector({
     source: vectorSource,
-    style: style
+    style: function(feature, resolution) {
+    style.getText().setText(document.getElementById('searchField').value);
+    return styles;
+  }
 });
 
 // Maps


### PR DESCRIPTION
### Short description
Fixes #196 
Added emoji markers for emojiHeatmapper app.
Demo link: https://kavithaenair.github.io/emojiHeatmapper/

**Screenshots for the change:**
![image](https://user-images.githubusercontent.com/18421291/27262071-e9921510-546c-11e7-8140-970b88e01185.png)

![image](https://user-images.githubusercontent.com/18421291/27262077-f964025a-546c-11e7-9448-31ec597c00d5.png)

I have:
- [x] There is a corresponding issue for this pull request.
- [x] Mentioned the Issue number in the pull request commit message `Fixes #<number> commit message`
- [x] There is only strictly only one commit per issue.

### For the reviewers
I have:
- [ ] Reviewed this pull request by an authorized contributor.
- [ ] The reviewer is assigned to the pull request.
