### PR TITLE
fixes #234 - added tweet statistics data for individual queries

### DIFF
--- a/MultiLinePlotter/css/styles.css
+++ b/MultiLinePlotter/css/styles.css
@@ -120,6 +120,28 @@ body {
     align-items: center;
 }
 
+.selected-tweet-stats {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    margin-bottom: 12px;
+}
+
+.tweet-stat {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+}
+
+.stat-label {
+    color: #616161;
+    text-align: center;
+}
+
+.stat-value {
+    color: #757575;
+}
+
 .stat-body {
     overflow: auto;
     height: 185px;
@@ -159,6 +181,11 @@ body {
     margin-bottom: 10px;
     box-shadow: 0 4px 8px 0 rgba(0,0,0,0.2);
     border-radius: 5px;
+    overflow-x: hidden;
+}
+
+.tweet-text {
+    word-wrap: break-word;
 }
 
 .tweet-item:hover {

--- a/MultiLinePlotter/index.html
+++ b/MultiLinePlotter/index.html
@@ -53,13 +53,28 @@
               <h4 class="modal-title">Tweets containing {{ modalHeading }}</h4>
             </div>
             <div class="modal-body modal-body-custom">
-              <div class="loading-tweets">
-                <div ng-if="tweetsLoading" class="loader" style="width: 50px; height: 50px; position: relative;"></div>
-                <div ng-if="tweetsLoading"> Fetching tweets... </div>
+              <div class="selected-tweet-stats">
+                <div class="tweet-stat max-tweet">
+                  <div class="stat-label"> <h4>Maximum number of tweets containing '{{modalHeading}}' :</h4></div>
+                  <div class="stat-value"> <strong>{{selectedTweetStat.maxTweetCount}}</strong> tweets on
+                    <strong>{{selectedTweetStat.maxTweetOn}}</strong>
+                  </div>
+                </div>
+                <div ng-if="selectedTweetStat.averageTweetsPerDay !== 0" class="tweet-stat avg-tweet">
+                  <div class="stat-label"> <h4>Average number of tweets containing '{{modalHeading}}' :</h4></div>
+                  <div class="stat-value">
+                    <strong>{{selectedTweetStat.averageTweetsPerDay}}</strong> tweets per day over a period of last
+                    <strong>{{selectedTweetStat.aggregationsLength}}</strong> days
+                  </div>
+                </div>
+              </div>
+              <div ng-if="tweetsLoading" class="loading-tweets">
+                <div class="loader" style="width: 50px; height: 50px; position: relative;"></div>
+                <div> Fetching tweets... </div>
               </div>
               <ul class="list-group stat-list tweet-list">
                 <div class="tweet-item list-group-item " ng-repeat="status in statuses">
-                  <div class="tweet_text">
+                  <div class="tweet-text">
                     {{ status.text }}
                   </div>
                   <div class="link_and_author">


### PR DESCRIPTION
fixes issue #234. Added individual tweet data including the date on
which the number of tweets containing a given word
was maximum and average number of tweets per day
over a period.

I have:
- [x] There is a corresponding issue for this pull request.
- [x] Mentioned the Issue number in the pull request commit message `Fixes #<number> commit message`
- [x] There is only strictly only one commit per issue.

### For the reviewers
I have:
- [ ] Reviewed this pull request by an authorized contributor.
- [ ] The reviewer is assigned to the pull request.
