### PR TITLE
fixes #236 -  Visualised tweet statistics for all the present queries

### DIFF
--- a/MultiLinePlotter/css/styles.css
+++ b/MultiLinePlotter/css/styles.css
@@ -47,6 +47,22 @@ body {
     box-shadow: 0 4px 8px 0 rgba(0,0,0,0.2);
 }
 
+.switch {
+    float: right;
+    cursor: pointer;
+    font-size: 18px;
+    color: #9e9e9e;
+    transition: color 0.3s;
+}
+
+.switch:hover {
+    color: #616161;
+}
+
+.header-text {
+    color: #616161;
+}
+
 .plot-data {
   overflow: auto;
   height: 270px;

--- a/MultiLinePlotter/index.html
+++ b/MultiLinePlotter/index.html
@@ -142,7 +142,17 @@
       <div class="row">
         <div class="col-md-12 col-plot">
           <div class="panel panel-default plot">
-            <div class="panel-heading">Aggregation Plot</div>
+            <div class="panel-heading">
+              <span ng-if="currentGraphType === 'aggregations'" class="header-text">
+                Aggregation Plot
+              </span>
+              <span ng-if="currentGraphType === 'stat'" class="header-text">
+                Statistics Plot (Maximum number of tweets and average number of tweets for queries)
+              </span>
+              <div class="switch" ng-click="toggle()">
+                <span ng-if="queryRecords.length !== 0" class="glyphicon glyphicon-stats"></span>
+              </div>
+            </div>
             <div id="graph" class="panel-body plot-data">
             </div>
           </div>


### PR DESCRIPTION
in MultiLinePlotter app.

Fixes issue #236 - Visualised tweet statistics for queries using
stacked barcharts.

I have:
- [x] There is a corresponding issue for this pull request.
- [x] Mentioned the Issue number in the pull request commit message `Fixes #<number> commit message`
- [x] There is only strictly only one commit per issue.

### For the reviewers
I have:
- [ ] Reviewed this pull request by an authorized contributor.
- [ ] The reviewer is assigned to the pull request.
